### PR TITLE
add souce client 

### DIFF
--- a/debian/TODO
+++ b/debian/TODO
@@ -11,7 +11,7 @@ What could be done:
  * automate creating the orig.tar.xz though this should be coordinated with
    upstream. Currently these commands can be used to create it:
    VERSION=0.3
-   git archive --format tar.gz --prefix=voctomix-$VERSION.orig/ -o ../voctomix_0.3.orig.tar.gz origin/master
+   git archive --format tar.gz --prefix=voctomix-$VERSION.orig/ -o ../voctomix_$VERSION.orig.tar.gz origin/master
    gunzip ../voctomix_$VERSION.orig.tar.gz
    xz ../voctomix_$VERSION.orig.tar
  * Not sure whether this should go into a new upstream Makefile or simply

--- a/debian/control
+++ b/debian/control
@@ -77,3 +77,12 @@ Description: Full-HD Software Live-Video-Mixer (GUI)
  This package contains the GUI component, Voctogui, a GUI implementation in
  GTK controlling the core's functionality.
 
+Package: voctomix-clients
+Architecture: all
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends},
+ voctomix-gui
+Description: Full-HD Software Live-Video-Mixer (clients)
+ .
+ Voctomix is written in Python using GStreamer by the CCC VOC.
+ .
+ This package contains the client components.

--- a/debian/rules
+++ b/debian/rules
@@ -23,13 +23,13 @@ override_dh_auto_install:
 		$(CURDIR)/debian/voctomix-gui/usr/share/voctomix/voctogui/
 	ln -s /usr/share/voctomix/voctogui/voctogui.py \
 		$(CURDIR)/debian/voctomix-gui/usr/bin/voctogui
+	ln -s /usr/share/voctomix/voctogui/ \
+		$(CURDIR)/debian/voctomix-gui/usr/lib/python3/dist-packages/voctogui
 	# voctomix-clients
 	cp -r example-scripts/gstreamer/ingest.py \
 	  	$(CURDIR)/debian/voctomix-clients/usr/share/voctomix/clients/
 	ln -s /usr/share/voctomix/clients/ingest.py \
 		$(CURDIR)/debian/voctomix-clients/usr/bin/ingest
-	ln -s /usr/share/voctomix/voctogui/ \
-		$(CURDIR)/debian/voctomix-clients/usr/lib/python3/dist-packages/voctogui
 
 override_dh_installdocs:
 	dh_installdocs

--- a/debian/rules
+++ b/debian/rules
@@ -14,11 +14,22 @@ override_dh_auto_build:
 override_dh_auto_install:
 	dh_auto_install
 	# voctomix-core
-	cp -r voctocore/default-config.ini voctocore/voctocore.py voctocore/lib $(CURDIR)/debian/voctomix-core/usr/share/voctomix/voctocore/
-	ln -s /usr/share/voctomix/voctocore/voctocore.py $(CURDIR)/debian/voctomix-core/usr/bin/voctocore
+	cp -r voctocore/default-config.ini voctocore/voctocore.py voctocore/lib \
+	   	$(CURDIR)/debian/voctomix-core/usr/share/voctomix/voctocore/
+	ln -s /usr/share/voctomix/voctocore/voctocore.py \
+		$(CURDIR)/debian/voctomix-core/usr/bin/voctocore
 	# voctomix-gui
-	cp -r voctogui/default-config.ini voctogui/voctogui.py voctogui/ui voctogui/lib $(CURDIR)/debian/voctomix-gui/usr/share/voctomix/voctogui/
-	ln -s /usr/share/voctomix/voctogui/voctogui.py $(CURDIR)/debian/voctomix-gui/usr/bin/voctogui
+	cp -r voctogui/default-config.ini voctogui/voctogui.py voctogui/ui voctogui/lib \
+		$(CURDIR)/debian/voctomix-gui/usr/share/voctomix/voctogui/
+	ln -s /usr/share/voctomix/voctogui/voctogui.py \
+		$(CURDIR)/debian/voctomix-gui/usr/bin/voctogui
+	# voctomix-clients
+	cp -r example-scripts/gstreamer/ingest.py \
+	  	$(CURDIR)/debian/voctomix-clients/usr/share/voctomix/clients/
+	ln -s /usr/share/voctomix/clients/ingest.py \
+		$(CURDIR)/debian/voctomix-clients/usr/bin/ingest
+	ln -s /usr/share/voctomix/voctogui/ \
+		$(CURDIR)/debian/voctomix-clients/usr/lib/python3/dist-packages/voctogui
 
 override_dh_installdocs:
 	dh_installdocs

--- a/debian/voctomix-clients.dirs
+++ b/debian/voctomix-clients.dirs
@@ -1,0 +1,3 @@
+usr/share/voctomix/clients
+usr/bin
+usr/lib/python3/dist-packages

--- a/debian/voctomix-clients.dirs
+++ b/debian/voctomix-clients.dirs
@@ -1,3 +1,2 @@
 usr/share/voctomix/clients
 usr/bin
-usr/lib/python3/dist-packages

--- a/debian/voctomix-gui.dirs
+++ b/debian/voctomix-gui.dirs
@@ -1,2 +1,3 @@
 usr/share/voctomix/voctogui
 usr/bin
+usr/lib/python3/dist-packages


### PR DESCRIPTION
There is code under gui/libs that talks to the server.  My source client uses that lib too.  so I added a symlink to the gui install so it would be on python's path so the client could use it.  No idea if this is best.
